### PR TITLE
update: enable gradle cache to speed up build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,6 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+# use cache to speed up build process
+org.gradle.configuration-cache=true
+org.gradle.caching=true


### PR DESCRIPTION
Added gradle build caching and configuration cache to speed up build process. 